### PR TITLE
CONSULTING-40 fixing issue with indexed query string

### DIFF
--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -27,5 +27,8 @@ exports.pipeRequest = function pipeRequest(req, res, url) {
     req.pipe(request({
         url: toAbsoluteURL(url),
         qs: req.query,
+        qsStringifyOptions: {
+            indices: false,
+        },
     })).pipe(res);
 };

--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -4,6 +4,11 @@ const urljoin = require('url-join');
 
 function toAbsoluteURL(url) {
     const serverRoot = localEnv.API_HOST || process.env.API_HOST || 'https://api.forio.com/v2';
+    // EpiJS automatically adds v2 to the original request
+    // Calls to the proxy may include a /v2/ which can cause issues
+    // If it exists, replace it with empty string to prevent issues
+    const versionPath = 'v2/';
+    url = url.replace(versionPath, '');
     const fullURL = urljoin(serverRoot, url);
     return fullURL;
 }


### PR DESCRIPTION
Under the `defaultProxy` function
If we make a call to `api-proxy/user/?account=ACCOUNT&id=userId1&userId2&userId3...`
Api Proxy will make a call to Epicenter as `user/?account=ACCOUNT&id[0]=userId1&id[1]=userId2...`
This in turn makes Epicenter ignore everything after `account=ACCOUNT`, so it returns a partial response to the user with X number of users in ACCOUNT, and not the specific ids we asked for.

`
qsStringifyOptions: {
            indices: false,
        },
`
fixes the issue so it makes the correct network call.
